### PR TITLE
Enable tailscaled's embedded HTTP proxy

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,6 +6,11 @@ ROUTES="${ROUTES:-}"
 EXTRA_ARGS="${EXTRA_ARGS:-}"
 USERSPACE="${USERSPACE:-true}"
 
+# If AUTH_KEY is not in env, attempt to find it under $AUTH_KEY_LOCAL_PATH
+if [ -z "${AUTH_KEY}" ] && [ ! -z  "${AUTH_KEY_LOCAL_PATH}" ];  then
+	AUTH_KEY=$(cat ${AUTH_KEY_LOCAL_PATH})
+fi
+
 set -e
 
 TAILSCALED_ARGS="--socket=/tmp/tailscaled.sock"

--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,7 @@ set -e
 TAILSCALED_ARGS="--socket=/tmp/tailscaled.sock"
 
 if [[ "${USERSPACE}" == "true" ]]; then
-  TAILSCALED_ARGS="${TAILSCALED_ARGS} --tun=userspace-networking"
+  TAILSCALED_ARGS="${TAILSCALED_ARGS} --tun=userspace-networking --outbound-http-proxy-listen=localhost:1055"
 else
   if [[ ! -d /dev/net ]]; then
     mkdir -p /dev/net


### PR DESCRIPTION
If the userspace networking implementation is used, we lose the ability
to add routes to the routing table and have processes hit Tailscale
addresses directly. In order to have outbound connectivity in these
cases an HTTP Proxy is used that essentially redirects Tailscale traffic
to tailscaled.

Also, allow for mounting the secret instead of passing it through an env var as well